### PR TITLE
remote型转发可在action中以$1,$2获取正则匹配项

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -43,7 +43,7 @@ var global = config.global,
     proxyAgent = global.proxy || '',
     proxyAgent = proxyAgent.split(':');
 
-// global 
+// global
 var httpServer, httpsServer, https2http;
 var liveapp;
 // request session id seed
@@ -120,7 +120,7 @@ livepool.run = function() {
 
         // new request come and notify to update web ui
         notify.request(sid, req, res);
-        // response filter, do something before return to browser, now is empty 
+        // response filter, do something before return to browser, now is empty
         response.getResInfo(res);
         // parse post body
         if (req.method == 'POST') {
@@ -171,7 +171,7 @@ livepool.run = function() {
 
     });
     httpServer.setMaxListeners(0);
-    httpServer.listen(httpPort, host);
+    httpServer.listen(httpPort);
     httpServer.on('clientError', function(err, socket) {
         logger.log('[client aborted]: ' + 'connection to livepool aborted'.grey);
     });
@@ -194,7 +194,7 @@ livepool.run = function() {
         });
     });
 
-    // directly forward websocket 
+    // directly forward websocket
     // TODO support websocket responders
     httpServer.on('upgrade', function(req, socket, head) {
         socket.write('HTTP/1.1 101 Web Socket Protocol Handshake\r\n' +

--- a/lib/livepool/config.js
+++ b/lib/livepool/config.js
@@ -251,7 +251,6 @@ config.getHandler = function(reqInfo, delay) {
         if (handler.match.indexOf('?') < 0) {
             urlRaw = urlPath;
         }
-
         if ((handler.match === urlRaw) || (urlRaw.indexOf(handler.match) >= 0) || new RegExp(handler.matchResolve).test(urlRaw)) {
             // 处理默认页访问 www.livepool.com
             pathname = (pathname == '/') ? ('/' + handler.indexPage) : pathname;

--- a/lib/livepool/responder/remote.js
+++ b/lib/livepool/responder/remote.js
@@ -7,6 +7,7 @@ function remoteResponder(handler, req, res, options) {
     //var reqUrl = url.parse(handler.action);
     //支持在action中以$1,$2获取正则匹配项
     //例如 http://nodejs.org/dist/(.*) => http://npm.taobao.org/mirrors/node/$1
+	console.log(req.url, new RegExp(handler.matchResolve));
     var reqUrl = url.parse(req.url.replace(new RegExp(handler.matchResolve), handler.action));
     var buffers = [];
     var options = {

--- a/lib/livepool/responder/remote.js
+++ b/lib/livepool/responder/remote.js
@@ -6,6 +6,7 @@ var http = require('http'),
 function remoteResponder(handler, req, res, options) {
     //var reqUrl = url.parse(handler.action);
     //支持在action中以$1,$2获取正则匹配项
+    //例如 http://nodejs.org/dist/(.*) => http://npm.taobao.org/mirrors/node/$1
     var reqUrl = url.parse(req.url.replace(new RegExp(handler.matchResolve), handler.action));
     var buffers = [];
     var options = {

--- a/lib/livepool/responder/remote.js
+++ b/lib/livepool/responder/remote.js
@@ -4,8 +4,9 @@ var http = require('http'),
     logger = require('../logger');
 
 function remoteResponder(handler, req, res, options) {
-
-    var reqUrl = url.parse(handler.action);
+    //var reqUrl = url.parse(handler.action);
+    //支持在action中以$1,$2获取正则匹配项
+    var reqUrl = url.parse(req.url.replace(new RegExp(handler.matchResolve), handler.action));
     var buffers = [];
     var options = {
         hostname: reqUrl.hostname,

--- a/lib/webui/liveapp.js
+++ b/lib/webui/liveapp.js
@@ -53,7 +53,7 @@ liveapp.run = function() {
     var uiport = config.global.uiport;
 	var uihost = config.global.uihost;
 
-    var server = liveapp.listen(uiport, uihost);
+    var server = liveapp.listen(uiport);
     liveapp.io = require('socket.io').listen(server);
 
     // browser connection -> keep only one socket connection


### PR DESCRIPTION
remote型转发可在action中以$1,$2获取正则匹配项
例如 http://nodejs.org/dist/(.*) => http://npm.taobao.org/mirrors/node/$1
